### PR TITLE
Fix typo in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Getting Started
 
 1. Go to [Pexels](https://www.pexels.com/api/), setup and account and generate an API key.
-2. `cp .env.example .env` and add your API key to the `.env` file.
+2. `cp env.example .env` and add your API key to the `.env` file.
 3. `npm install`
 4. `npm run dev` or `vite dev`
 5. Open [http://localhost:5173](http://localhost:5173) in your browser.


### PR DESCRIPTION
You could also just change the name of the example file